### PR TITLE
Close the clipboard after setting data

### DIFF
--- a/zyc/common.py
+++ b/zyc/common.py
@@ -475,5 +475,6 @@ class MyGrid(wx.grid.Grid):
         if wx.TheClipboard.Open():
             wx.TheClipboard.SetData(dataObj)
             wx.TheClipboard.Flush()
+            wx.TheClipboard.Close()
         else:
             Feedback("Unable to open clipboard!", "Error")

--- a/zyc/skidl_footprint_search.py
+++ b/zyc/skidl_footprint_search.py
@@ -526,6 +526,7 @@ class FootprintSearchPanel(wx.SplitterWindow):
         if wx.TheClipboard.Open():
             wx.TheClipboard.SetData(dataObj)
             wx.TheClipboard.Flush()
+            wx.TheClipboard.Close()
         else:
             Feedback("Unable to open clipboard!", "Error")
 

--- a/zyc/skidl_part_search.py
+++ b/zyc/skidl_part_search.py
@@ -459,6 +459,7 @@ class PartSearchPanel(wx.SplitterWindow):
         if wx.TheClipboard.Open():
             wx.TheClipboard.SetData(dataObj)
             wx.TheClipboard.Flush()
+            wx.TheClipboard.Close()
         else:
             Feedback("Unable to open clipboard!", "Error")
 
@@ -488,6 +489,7 @@ class PartSearchPanel(wx.SplitterWindow):
         if wx.TheClipboard.Open():
             wx.TheClipboard.SetData(dataObj)
             wx.TheClipboard.Flush()
+            wx.TheClipboard.Close()
         else:
             Feedback("Unable to open clipboard!", "Error")
 


### PR DESCRIPTION
Call `wx.TheClipboard.Close()` after setting the clipboard data.  Without
this, any copy operation after the first will fail on GTK/X11 with a
wxwidgets C++ assertion:

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/zyc/skidl_footprint_search.py", line 526, in OnCopy
    if wx.TheClipboard.Open():
wx._core.wxAssertionError: C++ assertion "!m_open" failed at ./src/gtk/clipbrd.cpp(598) in Open(): clipboard already open
```